### PR TITLE
Track referrer and page by default

### DIFF
--- a/src/analytics/playpass-analytics.ts
+++ b/src/analytics/playpass-analytics.ts
@@ -19,6 +19,8 @@ type EventData = {
     session_id: string;
     event_time: string; // ISO timestamp
     event_type: string;
+    page: string;
+    referrer: string;
     event_properties: Record<string,unknown>;
     user_properties: Record<string,unknown>;
 }
@@ -84,7 +86,9 @@ export class PlaypassAnalytics implements Analytics {
             session_id: this.sessionId,
             event_time: new Date().toISOString(),
             event_type: name,
-            event_properties: {...defaultEventProperties, ...(props || {})},
+            page: document.location.href,
+            referrer: document.referrer,
+            event_properties: (props || {}),
             user_properties: this.userProps,
         });
     }


### PR DESCRIPTION
Adds default tracking of url + referrer to all analytics event properties.

Verified in word game.