### PR TITLE
Modify feature-flag analytics shape, include browser language

### DIFF
--- a/src/featureFlags.ts
+++ b/src/featureFlags.ts
@@ -80,15 +80,7 @@ export function featureFlagIsEnabled (name: string): boolean {
 }
 
 function setFeatureFlagUserProp() {
-    // Put list of feature flags in an Amplitude user property
-    const featureFlagArray = [];
-    for (const featureFlag in cachedFeatureFlags) {
-        if (cachedFeatureFlags[featureFlag]) {
-            featureFlagArray.push(featureFlag);
-        }
-    }
-
     analytics.setUserProperties({
-        featureFlags: featureFlagArray,
+        featureFlags: cachedFeatureFlags,
     });
 }

--- a/src/gcinstant.ts
+++ b/src/gcinstant.ts
@@ -65,6 +65,7 @@ class AmplitudeAnalytics implements Analytics {
     }
 
     setUserProperties (props: Record<string,unknown>) {
+        // amplitude doesn't support featureFlags in a {key: value} format, so we flatten it into an array.
         const flattenedFeatureFlags = Object.entries(props.featureFlags as Record<string, unknown>).reduce((acc, [key, val]) => {
             if(val) {
                 acc.push(key);

--- a/src/gcinstant.ts
+++ b/src/gcinstant.ts
@@ -15,6 +15,7 @@ import { decode } from "./links";
 import { getPWADisplayMode } from "./pwa";
 import { getPlayerId } from "./init";
 import { internalStorage } from "./storage";
+import { isArray, isObject } from "util";
 
 let gcPlatform: PlatformImpl;
 
@@ -57,13 +58,24 @@ class PlatformImpl extends PlatformWeb {
     }
 }
 
+
 class AmplitudeAnalytics implements Analytics {
     track (name: string, props?: Record<string,unknown>) {
         gcAnalytics.pushEvent(name, props);
     }
 
     setUserProperties (props: Record<string,unknown>) {
-        gcAnalytics.setUserProperties(props);
+        const flattenedFeatureFlags = Object.entries(props.featureFlags as Record<string, unknown>).reduce((acc, [key, val]) => {
+            if(val) {
+                acc.push(key);
+            }
+            return acc;
+        }, [] as string[]);
+
+        gcAnalytics.setUserProperties({
+            ...props,
+            featureFlags: flattenedFeatureFlags,
+        } as Record<string, unknown>);
     }
 }
 

--- a/test/featureFlags/featureFlags.test.ts
+++ b/test/featureFlags/featureFlags.test.ts
@@ -43,7 +43,7 @@ describe("feature flag tests", () => {
         await playpass.createFeatureFlag("testFlag");
         playpass.setFeatureFlagEnabled("testFlag", true);
         expect(playpass.featureFlagIsEnabled("testFlag")).toBe(true);
-        expect(analyticsMock).toBeCalledWith({featureFlags: ["testFlag"]});
+        expect(analyticsMock).toBeCalledWith({featureFlags: {testFlag: true}});
         expect(mockDbSet).toBeCalled();
     });
 
@@ -51,7 +51,7 @@ describe("feature flag tests", () => {
         await playpass.createFeatureFlag("testFlag");
         playpass.setFeatureFlagEnabled("testFlag", false);
         expect(playpass.featureFlagIsEnabled("testFlag")).toBe(false);
-        expect(analyticsMock).toHaveBeenLastCalledWith({featureFlags: []});
+        expect(analyticsMock).toHaveBeenLastCalledWith({featureFlags: {testFlag: false}});
         expect(mockDbSet).toBeCalled();
     });
 
@@ -67,7 +67,7 @@ describe("feature flag tests", () => {
         });
 
         expect(playpass.featureFlagIsEnabled("testFlag")).toBe(false);
-        expect(analyticsMock).not.toBeCalledWith({featureFlags: ["testFlag"]});
+        expect(analyticsMock).not.toBeCalledWith({featureFlags: {testFlag: true}});
         expect(mockDbSet).toBeCalled();
     });
 
@@ -88,7 +88,7 @@ describe("feature flag tests", () => {
         });
 
         expect(playpass.featureFlagIsEnabled("testFlag")).toBe(true);
-        expect(analyticsMock).toBeCalledWith({featureFlags: ["testFlag"]});
+        expect(analyticsMock).toBeCalledWith({featureFlags: {testFlag: true}});
         expect(mockDbSet).toBeCalled();
     });
 
@@ -98,7 +98,7 @@ describe("feature flag tests", () => {
         });
 
         expect(playpass.featureFlagIsEnabled("testFlag")).toBe(false);
-        expect(analyticsMock).not.toBeCalledWith({featureFlags: ["testFlag"]});
+        expect(analyticsMock).toBeCalledWith({featureFlags: {testFlag: false}});
         expect(mockDbSet).toBeCalled();
     });
 
@@ -111,7 +111,7 @@ describe("feature flag tests", () => {
         });
 
         expect(playpass.featureFlagIsEnabled("testFlag")).toBe(true);
-        expect(analyticsMock).toBeCalledWith({featureFlags: ["testFlag"]});
+        expect(analyticsMock).toBeCalledWith({featureFlags: {testFlag: true}});
         expect(mockDbSet).toBeCalled();
     });
 
@@ -124,7 +124,7 @@ describe("feature flag tests", () => {
         });
 
         expect(playpass.featureFlagIsEnabled("testFlag")).toBe(false);
-        expect(analyticsMock).not.toBeCalledWith({featureFlags: ["testFlag"]});
+        expect(analyticsMock).not.toBeCalledWith({featureFlags: {testFlag: true}});
         expect(mockDbSet).toBeCalled();
     });
 
@@ -137,7 +137,7 @@ describe("feature flag tests", () => {
         });
 
         expect(playpass.featureFlagIsEnabled("testFlag")).toBe(false);
-        expect(analyticsMock).not.toBeCalledWith({featureFlags: ["testFlag"]});
+        expect(analyticsMock).not.toBeCalledWith({featureFlags: {testFlag: true}});
         expect(mockDbSet).toBeCalled();
     });
 
@@ -150,7 +150,7 @@ describe("feature flag tests", () => {
         });
 
         expect(playpass.featureFlagIsEnabled("testFlag")).toBe(false);
-        expect(analyticsMock).not.toBeCalledWith({featureFlags: ["testFlag"]});
+        expect(analyticsMock).not.toBeCalledWith({featureFlags: {testFlag: true}});
         expect(mockDbSet).toBeCalled();
     });
 });

--- a/test/featureFlags/featureFlagsInit.test.ts
+++ b/test/featureFlags/featureFlagsInit.test.ts
@@ -47,7 +47,11 @@ describe("feature flag tests", () => {
     it("includes decoded payload in feature flag initialization", async () => {
         await playpass.init();
         expect(mockDbGet).toHaveBeenCalledWith("featureFlags");
-        expect(analyticsMock).toBeCalledWith({featureFlags: ["testFlag", "testFlag3"]});
+        expect(analyticsMock).toBeCalledWith({featureFlags: {
+            "testFlag": true,
+            "testFlag2": false,
+            "testFlag3": true,
+        }});
         expect(mockDbSet).toBeCalled();
     });
 });


### PR DESCRIPTION
Note there is a change here with the way the feature flags work:

We now send the entire key->value array blob to the analytics systems. 