### PR TITLE
Have `playpass create` handle existing projects, and update docs.

### DIFF
--- a/docs/integration.md
+++ b/docs/integration.md
@@ -1,15 +1,12 @@
 # Integration
 
-If you're integrating the SDK into an existing game, follow these steps.
+If you're integrating Playpass into an existing game, follow the steps below. Before you start, make
+sure that you've [installed](/#1-install-playpass) the `playpass` CLI.
 
-## Installing
+## Adding Playpass to an existing project
 
-If your game uses a bundler like Webpack or Vite, you can install the SDK as a dependency using `npm
-install --save playpass`, then import it:
-
-```javascript
-import * as playpass from "playpass";
-```
+If your game uses a bundler like Webpack or Vite, you can run `playpass create` in your project
+directory. You'll be prompted to add Playpass to your existing project.
 
 If your game doesn't use a bundler, you can include the SDK as a script tag in your index.html:
 
@@ -17,13 +14,17 @@ If your game doesn't use a bundler, you can include the SDK as a script tag in y
 <script src="https://unpkg.com/playpass/dist/playpass.min.js"></script>
 ```
 
-## Initializing
+## Initializing Playpass
 
 The only requirement to using the Playpass SDK is calling `playpass.init()`.
 
 ```javascript
+import * as playpass from "playpass";
+
 // Initialize the Playpass SDK...
-await playpass.init();
+await playpass.init({
+    gameId: "<YOUR GAME ID HERE>"
+});
 
 // Continue with the rest of your game's initialization...
 ```

--- a/src/cli/create.ts
+++ b/src/cli/create.ts
@@ -26,8 +26,20 @@ async function prompt (obj: Partial<PromptObject>): Promise<string> {
     return value;
 }
 
+async function exists (file: string): Promise<boolean> {
+    try {
+        await fs.stat(file);
+        return true;
+    } catch (error) {
+        return false;
+    }
+}
+
 export async function create (destDir: string | undefined, opts: { template?: string }): Promise<void> {
     let subdomain: string;
+
+    // Whether we're creating using a template, or in-place adding Playpass to an existing project
+    let useTemplate = true;
 
     if (!destDir) {
         // No directory param provided, prompt them for a project ID and use it to form the dest dir
@@ -36,7 +48,16 @@ export async function create (destDir: string | undefined, opts: { template?: st
             message: "What will we call your project?",
             initial: "my-game",
         }));
-        destDir = path.resolve(subdomain);
+
+        if (await exists(process.cwd()+"/package.json")) {
+            useTemplate = !await prompt({
+                type: "confirm",
+                message: "This directory already contains a package.json, should we use it as an existing project?",
+                initial: true,
+            });
+        }
+
+        destDir = useTemplate ? path.resolve(subdomain) : process.cwd();
 
     } else {
         // They provided a dest dir, infer the project ID from it and make sure it's absolute
@@ -54,6 +75,31 @@ export async function create (destDir: string | undefined, opts: { template?: st
         // Continue
     }
 
+    let template;
+
+    if (useTemplate) {
+        try {
+            await fs.stat(destDir);
+            console.error(`Directory ${destDir} already exists. Please use a different name.`);
+            return;
+        } catch (error) {
+            // Continue
+        }
+
+        template = opts.template || await prompt({
+            type: "select",
+            name: "template",
+            message: "Choose a project template below",
+            choices: [
+                { title: "Daily Level Game", value: "daily-level" },
+                { title: "React Daily Level Game", value: "react-daily-level" },
+                { title: "Daily Word Game", value: "word-daily-level" },
+            ],
+        });
+    }
+
+    console.log();
+
     let game: Game;
     try {
         game = await playpassClient.create(subdomain);
@@ -61,49 +107,30 @@ export async function create (destDir: string | undefined, opts: { template?: st
         throw new Error("Failed to create game ${subdomain}, please try again");
     }
 
-    const template = opts.template || await prompt({
-        type: "select",
-        name: "template",
-        message: "Choose a project template below",
-        choices: [
-            { title: "Daily Level Game", value: "daily-level" },
-            { title: "React Daily Level Game", value: "react-daily-level" },
-            { title: "Daily Word Game", value: "word-daily-level" },
-        ],
-    });
+    if (useTemplate) {
+        const transform = (src: string, dest: string) => {
+            const ext = path.extname(src);
+            if (ext != ".js" && ext != ".jsx" && ext != ".ts" && ext != ".tsx") {
+                return null;
+            }
+            return replace("YOUR_GAME_ID", game.id);
+        };
 
-    console.log();
+        const templatesDir = `${__dirname}/../../../templates`;
+        await copy(`${templatesDir}/${template}`, destDir, { dot: true, junk: true, transform });
+        await copy(`${templatesDir}/common`, destDir, { dot: true, junk: true });
 
-    try {
-        await fs.stat(destDir);
-        console.error(`Directory ${destDir} already exists. Please use a different name.`);
-        return;
-    } catch (error) {
-        // Continue
+        // Update package.json. This is only to have a sensible default and not used by Playpass
+        const json = JSON.parse(await fs.readFile(destDir+"/package.json", "utf8"));
+        json.name = subdomain;
+        await fs.writeFile(destDir+"/package.json", JSON.stringify(json, null, "  "));
     }
-
-    const transform = (src: string, dest: string) => {
-        const ext = path.extname(src);
-        if (ext != ".js" && ext != ".jsx" && ext != ".ts" && ext != ".tsx") {
-            return null;
-        }
-        return replace("YOUR_GAME_ID", game.id);
-    };
-
-    const templatesDir = `${__dirname}/../../../templates`;
-    await copy(`${templatesDir}/${template}`, destDir, { dot: true, junk: true, transform });
-    await copy(`${templatesDir}/common`, destDir, { dot: true, junk: true });
 
     // Generate an initial playpass.toml
     await fs.writeFile(destDir+"/playpass.toml", [
         "# Your game's unique identifier. This should never change.",
         `game_id = "${game.id}"`,
     ].join("\n") + "\n");
-
-    // Also, update package.json. This is only to have a sensible default and not used by Playpass
-    const json = JSON.parse(await fs.readFile(destDir+"/package.json", "utf8"));
-    json.name = subdomain;
-    await fs.writeFile(destDir+"/package.json", JSON.stringify(json, null, "  "));
 
     console.log("Installing NPM dependencies, this may take a minute...");
 
@@ -113,18 +140,33 @@ export async function create (destDir: string | undefined, opts: { template?: st
     });
 
     console.log();
-    console.log(`${kleur.green("✔")} Created project at ${destDir}`);
-    console.log();
-    console.log("Develop it by running:");
-    console.log();
-    console.log("    npm start");
-    console.log();
-    console.log("Build for production by running:");
-    console.log();
-    console.log("    npm run build");
-    console.log();
-    console.log("Deploy it by pushing to GitHub, or manually running:");
-    console.log();
-    console.log("    playpass deploy");
-    console.log();
+
+    if (useTemplate) {
+        console.log(`${kleur.green("✔")} Created new project at ${destDir}`);
+        console.log();
+        console.log("Develop it by running:");
+        console.log();
+        console.log("    npm start");
+        console.log();
+        console.log("Build for production by running:");
+        console.log();
+        console.log("    npm run build");
+        console.log();
+        console.log("Deploy it by pushing to GitHub, or manually running:");
+        console.log();
+        console.log("    playpass deploy");
+        console.log();
+
+    } else {
+        console.log(`${kleur.green("✔")} Added Playpass to an existing project at ${destDir}`);
+        console.log();
+        console.log("To start using Playpass, edit your main JS file to add this import:");
+        console.log();
+        console.log("    import * as playpass from \"playpass\";");
+        console.log();
+        console.log("And paste this line into your game's initialization:");
+        console.log();
+        console.log(`    await playpass.init({ gameId: "${game.id}" });`);
+        console.log();
+    }
 }


### PR DESCRIPTION
If you run `playpass create` in an existing project with a package.json,
you'll be prompted to add Playpass to it instead of creating from a
template.

Choosing "yes" will reserve a game ID, generate a `playpass.toml`, and
print out some instructions of how to modify your game JS to init
playpass.
