### PR TITLE
Support initializing a project using an existing claimed game name

### DIFF
--- a/src/cli/create.ts
+++ b/src/cli/create.ts
@@ -28,7 +28,7 @@ async function prompt (obj: Partial<PromptObject>): Promise<string> {
     return value;
 }
 
-export async function create (destDir: string | undefined, opts: { template?: string, local?: boolean }): Promise<void> {
+export async function create (destDir: string | undefined, opts: { name?: string, template?: string, local?: boolean }): Promise<void> {
     let subdomain: string;
 
     // Whether we're creating using a template, or in-place adding Playpass to an existing project
@@ -37,26 +37,27 @@ export async function create (destDir: string | undefined, opts: { template?: st
 
     if (!destDir) {
         // No directory param provided, prompt them for a project ID and use it to form the dest dir
-        subdomain = slugify(await prompt({
+        subdomain = slugify(opts.name ?? await prompt({
             type: "text",
             message: "What will we call your project?",
             initial: "my-game",
         }));
 
-        if (await exists(process.cwd()+"/package.json")) {
-            useTemplate = !await prompt({
-                type: "confirm",
-                message: "This directory already contains a package.json, should we use it as an existing project?",
-                initial: true,
-            });
-        }
-
-        destDir = useTemplate ? path.resolve(subdomain) : process.cwd();
-
+        destDir = opts.name ? process.cwd() : path.resolve(subdomain);
     } else {
         // They provided a dest dir, infer the project ID from it and make sure it's absolute
-        subdomain = slugify(path.basename(destDir));
+        subdomain = slugify(opts.name ?? path.basename(destDir));
         destDir = path.resolve(destDir);
+    }
+
+    console.log(`New playpass project ${subdomain} will be created in ${destDir}`);
+
+    if (await exists(path.resolve(destDir, "package.json"))) {
+        useTemplate = !await prompt({
+            type: "confirm",
+            message: "This directory already contains a package.json, should we use it as an existing project?",
+            initial: true,
+        });
     }
 
     // when the local flag is set, we do not need to reserve resources in playpass cloud
@@ -65,19 +66,37 @@ export async function create (destDir: string | undefined, opts: { template?: st
     if (!opts.local) {
         const token = await requireToken();
         const playpassClient = new PlaypassClient(token);
-        try {
-            await playpassClient.checkGame(subdomain);
-            console.error(`Subdomain ${subdomain}.${playpassHost} already exists. Please use a different name.`);
-            return;
-        } catch (e) {
-            // Continue
-        }
 
-        try {
-            const game = await playpassClient.create(subdomain);
-            gameId = game.id;
-        } catch (e) {
-            throw new Error(`Failed to create game ${subdomain}, please try again`);
+        if (await playpassClient.checkGame(subdomain)) {
+            const games = await playpassClient.getGames();
+            const game = games.find((game) => game.name === subdomain);
+            
+            let proceed = false;
+            
+            if (game) {
+                const answer = await prompt({
+                    type: "confirm",
+                    message: `You already have an existing project named ${subdomain}.  Are you sure you wish to assign it to this project?`,
+                    initial: true,
+                });
+
+                if (answer) {
+                    gameId = game.id;
+                    proceed = true;
+                }
+            }
+            
+            if (!proceed) {
+                console.error(`Subdomain ${subdomain}.${playpassHost} already exists. Please use a different name.`);
+                return;    
+            }
+        } else {
+            try {
+                const game = await playpassClient.create(subdomain);
+                gameId = game.id;
+            } catch (e) {
+                throw new Error(`Failed to create game ${subdomain}, please try again`);
+            }
         }
     }
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -32,6 +32,7 @@ program
 
 program
     .command("create [directory]")
+    .option('--name <subdomain>', "Canonical name of your project.  This will be used as your subdomain.  Defaults to the directory name.")
     .option("--template <template>", "New project template.  Accepts git urls via degit")
     .option("-l, --local", "initializes the project locally without reserving a game id")
     .description("Create a new game project")

--- a/src/cli/playpass-client.ts
+++ b/src/cli/playpass-client.ts
@@ -2,8 +2,8 @@
 // Playpass (c) Playco
 // https://github.com/playpassgames/playpass/blob/main/LICENSE.txt
 
-import axios, {AxiosResponse, AxiosError} from "axios";
-import {playpassApiUrl} from "./config";
+import axios, { AxiosResponse, AxiosError } from "axios";
+import { playpassApiUrl } from "./config";
 
 export type PlaypassResponse = {
     result?: boolean | undefined,
@@ -50,17 +50,15 @@ export default class PlaypassClient {
         this.host = host;
     }
 
-    public async checkGame(game: string): Promise<void> {
-        return axios.request({
+    public async checkGame(game: string): Promise<boolean> {
+        return new Promise((resolve, reject) => axios.request({
             method: "HEAD",
             url: `${this.host}/api/v1/games/${game}`,
             headers: {
                 "X-API-TOKEN": this.authToken
             },
-        })
-            .then(() => {
-                return;
-            });
+        }).then(() => { resolve(true) })
+            .catch(() => { resolve(false) }));
     }
 
     public async getGames(): Promise<Game[]> {


### PR DESCRIPTION
This addresses the concerns of developers who ended up in a scenario where they wish to reuse a project name they have already claimed.  Such scenarios include

- wish to create a new project from scratch and want to replace an existing game they have
- accidentally deleted their project locally and need to start over, requiring they reclaim the name of the project they deleted
