### PR TITLE
Strip share payloads from URLs to keep them friendly.

### DIFF
--- a/src/init.ts
+++ b/src/init.ts
@@ -3,7 +3,7 @@
 // https://github.com/playpassgames/playpass/blob/main/LICENSE.txt
 
 import * as utils from "./utils";
-import { decode } from "./links";
+import { decode, stripPayloadsFromUrl } from "./links";
 import { initFeatureFlags } from "./featureFlags";
 import { internalStorage } from "./storage";
 import { analytics, playpassAnalytics } from "./analytics";
@@ -70,6 +70,12 @@ export async function init (opts?: InitOptions): Promise<void> {
 
     const payload = decode();
     const gcInstantEntryData = getGCInstantEntryData();
+
+    // Strip any payloads from the URL if needed
+    const strippedUrl = stripPayloadsFromUrl(location.href);
+    if (strippedUrl != location.href) {
+        history.replaceState(null, "", strippedUrl);
+    }
 
     playpassAnalytics.track("Entry", {
         // We need to track the ?payload URL param for marketing's ad params. Once we settle on a

--- a/src/links.ts
+++ b/src/links.ts
@@ -68,3 +68,25 @@ export function encode (payload: Payload): string {
 export function getLinkData (): unknown {
     return decode().data;
 }
+
+/** Remove payload params from the given URL. */
+export function stripPayloadsFromUrl (href: string): string {
+    const url = new URL(href);
+
+    // Strip the "link" param from the hash
+    const hash = new URL(url.hash.substring(1), url.origin);
+    if (hash.searchParams.has("link")) {
+        hash.searchParams.delete("link");
+        url.hash = hash.pathname + hash.search;
+
+        // If this would result in a bare #/ hash, clean out the entire thing
+        if (url.hash == "#/") {
+            url.hash = "";
+        }
+    }
+
+    // Also remove our old gcinstant legacy payload param
+    url.searchParams.delete("payload");
+
+    return url.toString();
+}

--- a/test/links.test.ts
+++ b/test/links.test.ts
@@ -4,7 +4,7 @@
 
 import "fake-indexeddb/auto";
 
-import { encode, decodeRaw } from "../src/links";
+import { encode, decodeRaw, stripPayloadsFromUrl } from "../src/links";
 
 describe("links", () => {
     it("should encode/decode payloads", () => {
@@ -38,5 +38,14 @@ describe("links", () => {
     it("should prioritize new links over legacy", () => {
         const decoded = decodeRaw("https://blingo.gg/#%7B%22channel%22:%22OLD%22%7D?link=%7B%22channel%22:%22NEW%22%7D");
         expect(decoded.channel).toBe("NEW");
+    });
+
+    it("should strip payloads", () => {
+        expect(stripPayloadsFromUrl("https://foobar.pixi.games:1234/path/subdir?keep1=123&payload=REMOVE&keep2=456#/hashpath/subdir?keep1=abc&link=ALSO_REMOVE&keep2=xyz"))
+            .toBe("https://foobar.pixi.games:1234/path/subdir?keep1=123&keep2=456#/hashpath/subdir?keep1=abc&keep2=xyz");
+
+        expect(stripPayloadsFromUrl("https://blingo.gg/nothing/?same=123")).toBe("https://blingo.gg/nothing/?same=123");
+
+        expect(stripPayloadsFromUrl("https://blingo.gg/#?link=xxx")).toBe("https://blingo.gg/");
     });
 });


### PR DESCRIPTION
And also to prevent double attribution.
