### PR TITLE
Fix GCInstant attribution

### DIFF
--- a/src/gcinstant.ts
+++ b/src/gcinstant.ts
@@ -81,6 +81,7 @@ class AmplitudeAnalytics implements Analytics {
 }
 
 export async function initGCInstant (opts?: { amplitude: string, abTestConfig?: ABConfig, hashFunction?: HashFunction }): Promise<void> {
+    console.log('initing gcinstant w/ v2.0 analytics fix')
     injectSecondaryAnalytics(new AmplitudeAnalytics());
 
     gcPlatform = new PlatformImpl();

--- a/src/gcinstant.ts
+++ b/src/gcinstant.ts
@@ -126,6 +126,7 @@ export function assignTestManually(testId: string, bucketId?: string): void {
 }
 
 export function getGCSharePayload() {
+  // Due to size constraints on link shortener we strip out a lot of gcinstants default payload and only use the parts we need.
   const gcinstantSharePropertyWhitelist = [
     'playerID',
     '$firstEntryGeneration',

--- a/src/gcinstant.ts
+++ b/src/gcinstant.ts
@@ -52,7 +52,7 @@ class PlatformImpl extends PlatformWeb {
         this.setPlayerID(playerId);
     }
 
-    /** Grab entry point data from link payload. */
+    /** If gcinstant is set, use that. Otherwise fallback on the default gcinstant handling for `payload` */
     public override _getEntryPointDataForce(): AnalyticsProperties.EntryData {
         return decode().gcinstant as AnalyticsProperties.EntryData || super._getEntryPointDataForce();
     }
@@ -122,4 +122,8 @@ export function getBucketId(testId: string): string | undefined {
 
 export function assignTestManually(testId: string, bucketId?: string): void {
     gcPlatform.abTests?.assignTestManually(testId, bucketId);
+}
+
+export function getGCSharePayload() {
+  return gcPlatform ? gcPlatform.getPlatformPayloadData() : {};
 }

--- a/src/gcinstant.ts
+++ b/src/gcinstant.ts
@@ -126,5 +126,22 @@ export function assignTestManually(testId: string, bucketId?: string): void {
 }
 
 export function getGCSharePayload() {
-  return gcPlatform ? gcPlatform.getPlatformPayloadData() : {};
+  const gcinstantSharePropertyWhitelist = [
+    'playerID',
+    '$firstEntryGeneration',
+    /\$?zeroEntry/,
+  ]
+  // we filter this because of size constraints.
+  const payload = gcPlatform ? gcPlatform.getPlatformPayloadData() : {};
+  const filteredPayload = Object.entries(payload).reduce((acc, [key, val]) => {
+    const matchFound = !!gcinstantSharePropertyWhitelist.find(matcher => {
+      if(matcher instanceof RegExp) return matcher.test(key)
+      else return matcher === key
+    })
+    if(matchFound) {
+      acc[key] = val;
+    }
+    return acc;
+  }, {} as Record<string, string>);
+  return filteredPayload;
 }

--- a/src/gcinstant.ts
+++ b/src/gcinstant.ts
@@ -81,7 +81,6 @@ class AmplitudeAnalytics implements Analytics {
 }
 
 export async function initGCInstant (opts?: { amplitude: string, abTestConfig?: ABConfig, hashFunction?: HashFunction }): Promise<void> {
-    console.log('initing gcinstant w/ v2.0 analytics fix')
     injectSecondaryAnalytics(new AmplitudeAnalytics());
 
     gcPlatform = new PlatformImpl();
@@ -126,23 +125,23 @@ export function assignTestManually(testId: string, bucketId?: string): void {
 }
 
 export function getGCSharePayload() {
-  // Due to size constraints on link shortener we strip out a lot of gcinstants default payload and only use the parts we need.
-  const gcinstantSharePropertyWhitelist = [
-    'playerID',
-    '$firstEntryGeneration',
-    /\$?zeroEntry/,
-  ]
-  // we filter this because of size constraints.
-  const payload = gcPlatform ? gcPlatform.getPlatformPayloadData() : {};
-  const filteredPayload = Object.entries(payload).reduce((acc, [key, val]) => {
-    const matchFound = !!gcinstantSharePropertyWhitelist.find(matcher => {
-      if(matcher instanceof RegExp) return matcher.test(key)
-      else return matcher === key
-    })
-    if(matchFound) {
-      acc[key] = val;
-    }
-    return acc;
-  }, {} as Record<string, string>);
-  return filteredPayload;
+    // Due to size constraints on link shortener we strip out a lot of gcinstants default payload and only use the parts we need.
+    const gcinstantSharePropertyWhitelist = [
+        "playerID",
+        "$firstEntryGeneration",
+        /\$?zeroEntry/,
+    ];
+    // we filter this because of size constraints.
+    const payload = gcPlatform ? gcPlatform.getPlatformPayloadData() : {};
+    const filteredPayload = Object.entries(payload).reduce((acc, [key, val]) => {
+        const matchFound = !!gcinstantSharePropertyWhitelist.find(matcher => {
+            if(matcher instanceof RegExp) return matcher.test(key);
+            else return matcher === key;
+        });
+        if(matchFound) {
+            acc[key] = val;
+        }
+        return acc;
+    }, {} as Record<string, string>);
+    return filteredPayload;
 }

--- a/src/share/index.ts
+++ b/src/share/index.ts
@@ -4,12 +4,13 @@
 
 import { analytics } from "../analytics";
 import { encode } from "../links";
-import { getGCInstantEntryData, getPlayerId } from "../init";
+import { getPlayerId } from "../init";
 import { shortHash } from "../utils";
 
 import { ShareType } from "./share-type";
 
 import "../ui/share-popup";
+import { getGCSharePayload } from "../gcinstant";
 
 export type { ShareType };
 
@@ -174,7 +175,7 @@ export function createLink(opts?: CreateLinkOptions) {
 
         // TODO(2022-03-18): Remove, gcinstant only
         gcinstant: {
-            ...getGCInstantEntryData(),
+            ...getGCSharePayload(),
             $channel: opts?.channel ?? "SHARE",
         },
     });

--- a/src/share/index.ts
+++ b/src/share/index.ts
@@ -4,7 +4,7 @@
 
 import { analytics } from "../analytics";
 import { encode } from "../links";
-import { getPlayerId } from "../init";
+import { getGCInstantEntryData, getPlayerId } from "../init";
 import { shortHash } from "../utils";
 
 import { ShareType } from "./share-type";
@@ -174,8 +174,8 @@ export function createLink(opts?: CreateLinkOptions) {
 
         // TODO(2022-03-18): Remove, gcinstant only
         gcinstant: {
+            ...getGCInstantEntryData(),
             $channel: opts?.channel ?? "SHARE",
-            playerID: getPlayerId(),
         },
     });
 


### PR DESCRIPTION
Fixes the missing `zeroEntry` payload data. Previously we were not passing any of the internal gcinstant payload through the referral links. This uses GCInstants `.getPlatformPayloadData()` which is designed for creating referral payloads.

We are stripping the parameters back to just `$zeroEntryXXX` and a few others because the link shortener has a length limit, and if we use the full payload it exceeds the limit. 

I have verified this against whatsmyword and it fixes the missing zeroEntry data issues