### PR TITLE
decode gcinstant before stripping

### DIFF
--- a/src/gcinstant.ts
+++ b/src/gcinstant.ts
@@ -20,10 +20,14 @@ import getQueryParameters from "./utils";
 
 let gcPlatform: PlatformImpl;
 
+// this should never be fatal.
 function getEntryPointData(): AnalyticsProperties.EntryData {
-    const decoded = decode().gcinstant as AnalyticsProperties.EntryData;
-    if (decoded) return decoded;
     try {
+        // internal share payload format
+        const decoded = decode().gcinstant as AnalyticsProperties.EntryData;
+        if (decoded) return decoded;
+
+        // else we use the old gcinstant payload handling format.
         const { payload } = getQueryParameters();
         if (payload) {
             return JSON.parse(payload);

--- a/src/gcinstant.ts
+++ b/src/gcinstant.ts
@@ -16,8 +16,26 @@ import { getPWADisplayMode } from "./pwa";
 import { getPlayerId } from "./init";
 import { internalStorage } from "./storage";
 import { isArray, isObject } from "util";
+import getQueryParameters from "./utils";
 
 let gcPlatform: PlatformImpl;
+
+function getEntryPointData(): AnalyticsProperties.EntryData {
+  const decoded = decode().gcinstant as AnalyticsProperties.EntryData
+  if(decoded) return decoded;
+  try {
+      const { payload } = getQueryParameters();
+      if (payload) {
+        return JSON.parse(payload);
+      }
+    } catch (error) {
+      console.error('Failed to decode gcinstant payload', error);
+    }
+  return {} as AnalyticsProperties.EntryData;
+}
+
+// we invoke this on load because the URL will get stripped when playpass inits. 
+const entryPointData = getEntryPointData();
 
 class PlatformImpl extends PlatformWeb {
     /** Same as initializeAsync, but pass the player ID to initialize Amplitude. */
@@ -54,7 +72,7 @@ class PlatformImpl extends PlatformWeb {
 
     /** If gcinstant is set, use that. Otherwise fallback on the default gcinstant handling for `payload` */
     public override _getEntryPointDataForce(): AnalyticsProperties.EntryData {
-        return decode().gcinstant as AnalyticsProperties.EntryData || super._getEntryPointDataForce();
+        return entryPointData;
     }
 }
 

--- a/src/gcinstant.ts
+++ b/src/gcinstant.ts
@@ -21,17 +21,17 @@ import getQueryParameters from "./utils";
 let gcPlatform: PlatformImpl;
 
 function getEntryPointData(): AnalyticsProperties.EntryData {
-  const decoded = decode().gcinstant as AnalyticsProperties.EntryData
-  if (decoded) return decoded;
-  try {
-    const { payload } = getQueryParameters();
-    if (payload) {
-      return JSON.parse(payload);
+    const decoded = decode().gcinstant as AnalyticsProperties.EntryData;
+    if (decoded) return decoded;
+    try {
+        const { payload } = getQueryParameters();
+        if (payload) {
+            return JSON.parse(payload);
+        }
+    } catch (error) {
+        console.error("Failed to decode gcinstant payload", error);
     }
-  } catch (error) {
-    console.error('Failed to decode gcinstant payload', error);
-  }
-  return {} as AnalyticsProperties.EntryData;
+    return {} as AnalyticsProperties.EntryData;
 }
 
 // we invoke this on load because the URL will get stripped when playpass inits. 

--- a/src/gcinstant.ts
+++ b/src/gcinstant.ts
@@ -22,15 +22,15 @@ let gcPlatform: PlatformImpl;
 
 function getEntryPointData(): AnalyticsProperties.EntryData {
   const decoded = decode().gcinstant as AnalyticsProperties.EntryData
-  if(decoded) return decoded;
+  if (decoded) return decoded;
   try {
-      const { payload } = getQueryParameters();
-      if (payload) {
-        return JSON.parse(payload);
-      }
-    } catch (error) {
-      console.error('Failed to decode gcinstant payload', error);
+    const { payload } = getQueryParameters();
+    if (payload) {
+      return JSON.parse(payload);
     }
+  } catch (error) {
+    console.error('Failed to decode gcinstant payload', error);
+  }
   return {} as AnalyticsProperties.EntryData;
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -16,7 +16,7 @@ export default function getQueryParameters(url?: string): {
   [key: string]: string;
 } {
   const search = url ? new URL(url).search : window.location.search;
-  const params = {};
+  const params: Record<string, string> = {};
   new URLSearchParams(search).forEach((value, key) => (params[key] = value));
   return params;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -15,10 +15,10 @@ export function randomId (prefix: string) {
 export default function getQueryParameters(url?: string): {
   [key: string]: string;
 } {
-  const search = url ? new URL(url).search : window.location.search;
-  const params: Record<string, string> = {};
-  new URLSearchParams(search).forEach((value, key) => (params[key] = value));
-  return params;
+    const search = url ? new URL(url).search : window.location.search;
+    const params: Record<string, string> = {};
+    new URLSearchParams(search).forEach((value, key) => (params[key] = value));
+    return params;
 }
 
 export function shortHash (input: string) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -12,6 +12,15 @@ export function randomId (prefix: string) {
     return str;
 }
 
+export default function getQueryParameters(url?: string): {
+  [key: string]: string;
+} {
+  const search = url ? new URL(url).search : window.location.search;
+  const params = {};
+  new URLSearchParams(search).forEach((value, key) => (params[key] = value));
+  return params;
+}
+
 export function shortHash (input: string) {
     // First calculate an unsigned 32 bit hash of the input
     let n = 0;

--- a/test/featureFlags/featureFlagsInit.test.ts
+++ b/test/featureFlags/featureFlagsInit.test.ts
@@ -10,6 +10,15 @@ import { IDBStorage } from "../../src/storage/idb-storage";
 
 import * as playpass from "../../src";
 
+jest.mock("./../../src/links", () => {
+    const old = jest.requireActual("./../../src/links");
+    return {
+        ...old,
+        decode: jest.fn().mockReturnValue({}),
+        encode: jest.fn().mockReturnValue({}),
+    };
+});
+
 describe("feature flag tests", () => {
     // Hide noisy console logs:
     console.error = jest.fn();
@@ -36,9 +45,8 @@ describe("feature flag tests", () => {
         },
         gcinstant: {}
     };
-    location.href = links.encode(mockPayload);
     const analyticsMock = jest.spyOn(analytics, "setUserProperties");
-    // jest.spyOn(links, 'decode').mockReturnValue(mockPayload);
+    jest.spyOn(links, "decode").mockReturnValue(mockPayload);
 
     beforeEach(() => {
         jest.clearAllMocks();


### PR DESCRIPTION
Changes the gcinstant payload decoder to fire on load before the stripping occurs in playpass.init.

This captures the same logic as previously, but we can't invoke the `super._getEntryPointDataForce()` helper like we were before since gcinstant is not initialized. 