### PR TITLE
move share code into a container while maintaining compatible API

### DIFF
--- a/src/gcinstant.ts
+++ b/src/gcinstant.ts
@@ -15,8 +15,10 @@ import { decode } from "./links";
 import { getPWADisplayMode } from "./pwa";
 import { getPlayerId } from "./init";
 import { internalStorage } from "./storage";
-import { isArray, isObject } from "util";
 import getQueryParameters from "./utils";
+
+import type { CreateLinkOptions } from "./share";
+import share from "./share";
 
 let gcPlatform: PlatformImpl;
 
@@ -136,6 +138,21 @@ export async function initGCInstant (opts?: { amplitude: string, abTestConfig?: 
     // Send an EntryFinal to Amplitude
     await gcPlatform.startGameAsync();
     void gcPlatform.sendEntryFinalAnalytics({}, {}, {});
+
+    // decorate share link data with gcinstant payload information
+    const getLinkPayload = share.getLinkPayload;
+    share.getLinkPayload = function (opts?: CreateLinkOptions) {
+        const payload = getLinkPayload(opts);
+        return {
+            ...payload,
+            
+            // TODO(2022-03-18): Remove, gcinstant only
+            gcinstant: {
+                ...getGCSharePayload(),
+                ...payload.gcinstant,
+            },
+        };
+    };
 }
 
 export function getBucketId(testId: string): string | undefined {

--- a/src/share/index.ts
+++ b/src/share/index.ts
@@ -10,7 +10,6 @@ import { shortHash } from "../utils";
 import { ShareType } from "./share-type";
 
 import "../ui/share-popup";
-import { getGCSharePayload } from "../gcinstant";
 
 export type { ShareType };
 
@@ -35,203 +34,219 @@ export type CreateLinkOptions = {
     data?: unknown,
 };
 
-/**
- * Open the device share dialog.
- *
- * WARNING! This function must be called in a user gesture handler such as pointerup.
- *
- * Sending a share with a game link:
- * ```javascript
- * playpass.share({
- *   text: "Here's a coin gift for you: " + playpass.createLink({data: { coins: 123 } }),
- * });
- * ```
- *
- * Receive data from the game link:
- * ```javascript
- * const data = playpass.getLinkData();
- * if (data) {
- *     console.log("Opened a link with coins!", data.coins);
- * }
- * ```
- *
- * @returns Whether the share was successfully sent.
- */
-export async function share(opts?: ShareOptions): Promise<boolean> {
-    const files = opts?.files || [];
+class ShareService {
+    
+    private openNewTab (url: string, params: Record<string,string>) {
+        const u = new URL(url);
+        for (const key in params) {
+            u.searchParams.set(key, params[key]);
+        }
+        window.open(u.toString(), "_blank", "noopener");
+        // TODO(2022-05-16): Detect popup blocked
+    }
 
-    // If we didn't receive a text or files, just share a simple link
-    const text = (opts?.text || files.length) ? opts?.text : createLink();
+    private async callShortener (longUrl: string): Promise<void> {
+        const response = await fetch("https://api.playpass.link", {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                "Authorization": "Basic d29yZHMuZ2c6RHV4ZXRTMVhPTXBEd3JjZA==",
+            },
+            body: JSON.stringify({
+                url: longUrl,
+            }),
+        });
 
-    const type = opts?.type || ShareType.Any;
-
-    const trackParams = { fileCount: files.length, textLength: text?.length ?? 0, type };
-    analytics.track("SharePrompted", trackParams);
-
-    const shareData = { files, text };
-
-    let shareSent = false;
-
-    if (type == ShareType.Any) {
-        // Check for ontouchstart to blacklist desktop browsers in order to prevent using Chrome's
-        // goofy share UX on Windows
-        if (navigator.canShare?.(shareData) && navigator.share && "ontouchstart" in document.documentElement) {
-            try {
-                await navigator.share(shareData);
-                shareSent = true;
-            } catch (error: unknown) {
-                if (!(error instanceof Error)) {
-                    throw error;
-                }
-                if (error.name == "AbortError") {
-                    analytics.track("ShareRejected", trackParams);
+        await response.json();
+    }
+    
+    async copyToClipboard (text: string): Promise<void> {
+        try {
+            analytics.track("ClipboardCopy");
+    
+            // Attempt to use the async clipboard API, which is not universally supported
+            await navigator.clipboard.writeText(text);
+            analytics.track("ClipboardCopySuccess");
+        } catch {
+            // Fall back to using execCommand on a dummy textarea element
+            const textArea = document.createElement("textarea");
+    
+            textArea.value = text;
+    
+            textArea.style.position = "fixed";
+            textArea.style.left = "-999999px";
+            textArea.style.top = "-999999px";
+            document.body.appendChild(textArea);
+            textArea.focus();
+            textArea.select();
+    
+            return new Promise((resolve, reject) => {
+                if (document.execCommand("copy")) {
+                    analytics.track("ClipboardCopySuccess");
+                    resolve();
                 } else {
-                    analytics.track("ShareError", {...trackParams, error: error.name});
+                    analytics.track("ClipboardCopyFailure");
+                    reject(new Error("execCommand copy failed"));
                 }
-            }
-
-        } else if (text) {
-            shareSent = await new Promise(resolve => {
-                const popup = document.createElement("playpass-share");
-                popup.shareText = text;
-                popup.onShare = type => {
-                    resolve(type ? doShare(type, text) : false);
-                };
-                document.body.appendChild(popup);
+                textArea.remove();
             });
         }
-
-    } else if (text && await doShare(type, text)) {
-        shareSent = true;
     }
 
-    if (shareSent) {
-        analytics.track("ShareSent", trackParams);
+    createLink(opts?: CreateLinkOptions) {
+        // During local development or games hosted on *.playpass.games, use a fixed short domain
+        const shortDomain = (location.port || location.hostname.endsWith(".playpass.games"))
+            ? "playpass.link"
+            : location.hostname;
+    
+        const longUrl = encode(this.getLinkPayload(opts));
+    
+        // Perform a background API request to actually create the shortlink
+        void this.callShortener(longUrl);
+    
+        // We locally compute what the shortlink will be to avoid waiting
+        return `https://${shortDomain}/${shortHash(longUrl)}`;
     }
-    return shareSent;
-}
 
-async function doShare (type: ShareType, text: string): Promise<boolean> {
-    const urlPattern = /\bhttps?:\/\/[^\s]+/;
-    const urlMatch = text.match(urlPattern);
-    const textNoUrls = text.replace(urlPattern, "").trim();
-
-    switch (type) {
-    case ShareType.Facebook:
-        openNewTab("https://www.facebook.com/sharer/sharer.php", {
-            quote: textNoUrls,
-            u: urlMatch ? urlMatch[0] : createLink(),
-        });
-        return true;
-
-    case ShareType.Twitter:
-        openNewTab("https://twitter.com/intent/tweet", { text });
-        return true;
-
-    case ShareType.WhatsApp:
-        openNewTab("https://api.whatsapp.com/send", { text });
-        return true;
-
-    case ShareType.Telegram:
-        openNewTab("https://telegram.me/share/msg", {
-            text: textNoUrls,
-            url: urlMatch ? urlMatch[0] : createLink(),
-        });
-        return true;
-
-    case ShareType.Clipboard:
-        void copyToClipboard(text);
-        return true;
-
-    default:
-        throw new Error(`Unsupported share type: ${type}`);
+    getLinkPayload(opts?: CreateLinkOptions) {
+        return {
+            channel: opts?.channel ?? "SHARE",
+            data: opts?.data,
+            referrer: getPlayerId(),
+    
+            // TODO(2022-03-18): Remove, gcinstant only
+            gcinstant: {
+                $channel: opts?.channel ?? "SHARE",
+            },
+        };
     }
-}
 
-function openNewTab (url: string, params: Record<string,string>) {
-    const u = new URL(url);
-    for (const key in params) {
-        u.searchParams.set(key, params[key]);
+    private async doShare (type: ShareType, text: string): Promise<boolean> {
+        const urlPattern = /\bhttps?:\/\/[^\s]+/;
+        const urlMatch = text.match(urlPattern);
+        const textNoUrls = text.replace(urlPattern, "").trim();
+    
+        switch (type) {
+        case ShareType.Facebook:
+            this.openNewTab("https://www.facebook.com/sharer/sharer.php", {
+                quote: textNoUrls,
+                u: urlMatch ? urlMatch[0] : this.createLink(),
+            });
+            return true;
+    
+        case ShareType.Twitter:
+            this.openNewTab("https://twitter.com/intent/tweet", { text });
+            return true;
+    
+        case ShareType.WhatsApp:
+            this.openNewTab("https://api.whatsapp.com/send", { text });
+            return true;
+    
+        case ShareType.Telegram:
+            this.openNewTab("https://telegram.me/share/msg", {
+                text: textNoUrls,
+                url: urlMatch ? urlMatch[0] : this.createLink(),
+            });
+            return true;
+    
+        case ShareType.Clipboard:
+            void this.copyToClipboard(text);
+            return true;
+    
+        default:
+            throw new Error(`Unsupported share type: ${type}`);
+        }
     }
-    window.open(u.toString(), "_blank", "noopener");
-    // TODO(2022-05-16): Detect popup blocked
-}
 
-/**
- * Generate a short link for sharing the game.  Use this when a shareable link is desired for use outside of the `share` method.
- * @param opts - CreateLinkOptions
- * @returns A string representing the shortened url containing the payload data
- */
-export function createLink(opts?: CreateLinkOptions) {
-    // During local development or games hosted on *.playpass.games, use a fixed short domain
-    const shortDomain = (location.port || location.hostname.endsWith(".playpass.games"))
-        ? "playpass.link"
-        : location.hostname;
+    /**
+     * Open the device share dialog.
+     *
+     * WARNING! This function must be called in a user gesture handler such as pointerup.
+     *
+     * Sending a share with a game link:
+     * ```javascript
+     * playpass.share({
+     *   text: "Here's a coin gift for you: " + playpass.createLink({data: { coins: 123 } }),
+     * });
+     * ```
+     *
+     * Receive data from the game link:
+     * ```javascript
+     * const data = playpass.getLinkData();
+     * if (data) {
+     *     console.log("Opened a link with coins!", data.coins);
+     * }
+     * ```
+     *
+     * @returns Whether the share was successfully sent.
+     */
+    async share(opts?: ShareOptions): Promise<boolean> {
+        const files = opts?.files || [];
 
-    const longUrl = encode({
-        channel: opts?.channel ?? "SHARE",
-        data: opts?.data,
-        referrer: getPlayerId(),
+        // If we didn't receive a text or files, just share a simple link
+        const text = (opts?.text || files.length) ? opts?.text : this.createLink();
 
-        // TODO(2022-03-18): Remove, gcinstant only
-        gcinstant: {
-            ...getGCSharePayload(),
-            $channel: opts?.channel ?? "SHARE",
-        },
-    });
+        const type = opts?.type || ShareType.Any;
 
-    // Perform a background API request to actually create the shortlink
-    void callShortener(longUrl);
+        const trackParams = { fileCount: files.length, textLength: text?.length ?? 0, type };
+        analytics.track("SharePrompted", trackParams);
 
-    // We locally compute what the shortlink will be to avoid waiting
-    return `https://${shortDomain}/${shortHash(longUrl)}`;
-}
+        const shareData = { files, text };
 
-async function callShortener (longUrl: string): Promise<void> {
-    const response = await fetch("https://api.playpass.link", {
-        method: "POST",
-        headers: {
-            "Content-Type": "application/json",
-            "Authorization": "Basic d29yZHMuZ2c6RHV4ZXRTMVhPTXBEd3JjZA==",
-        },
-        body: JSON.stringify({
-            url: longUrl,
-        }),
-    });
+        let shareSent = false;
 
-    await response.json();
-}
+        if (type == ShareType.Any) {
+            // Check for ontouchstart to blacklist desktop browsers in order to prevent using Chrome's
+            // goofy share UX on Windows
+            if (navigator.canShare?.(shareData) && navigator.share && "ontouchstart" in document.documentElement) {
+                try {
+                    await navigator.share(shareData);
+                    shareSent = true;
+                } catch (error: unknown) {
+                    if (!(error instanceof Error)) {
+                        throw error;
+                    }
+                    if (error.name == "AbortError") {
+                        analytics.track("ShareRejected", trackParams);
+                    } else {
+                        analytics.track("ShareError", {...trackParams, error: error.name});
+                    }
+                }
 
-/** @hidden */
-export async function copyToClipboard (text: string): Promise<void> {
-    try {
-        analytics.track("ClipboardCopy");
-
-        // Attempt to use the async clipboard API, which is not universally supported
-        await navigator.clipboard.writeText(text);
-        analytics.track("ClipboardCopySuccess");
-    } catch {
-        // Fall back to using execCommand on a dummy textarea element
-        const textArea = document.createElement("textarea");
-
-        textArea.value = text;
-
-        textArea.style.position = "fixed";
-        textArea.style.left = "-999999px";
-        textArea.style.top = "-999999px";
-        document.body.appendChild(textArea);
-        textArea.focus();
-        textArea.select();
-
-        return new Promise((resolve, reject) => {
-            if (document.execCommand("copy")) {
-                analytics.track("ClipboardCopySuccess");
-                resolve();
-            } else {
-                analytics.track("ClipboardCopyFailure");
-                reject(new Error("execCommand copy failed"));
+            } else if (text) {
+                shareSent = await new Promise(resolve => {
+                    const popup = document.createElement("playpass-share");
+                    popup.shareText = text;
+                    popup.onShare = type => {
+                        resolve(type ? this.doShare(type, text) : false);
+                    };
+                    document.body.appendChild(popup);
+                });
             }
-            textArea.remove();
-        });
+
+        } else if (text && await this.doShare(type, text)) {
+            shareSent = true;
+        }
+
+        if (shareSent) {
+            analytics.track("ShareSent", trackParams);
+        }
+        return shareSent;
     }
+}
+
+const service = new ShareService(); 
+
+export default service;
+
+export function createLink(opts?: CreateLinkOptions) {
+    return service.createLink(opts);
+}
+
+export async function share(opts?: ShareOptions) {
+    return service.share(opts);
+}
+
+export async function copyToClipboard (text: string) {
+    return service.copyToClipboard(text);
 }


### PR DESCRIPTION
allows for decorating/mutating the functions, which in turn allows gcinstant to inject its functionality onto the share API instead of having share be dependent on gcinstant/private libraries.