### PR TITLE
replicant-lite@1.4.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@iarna/toml": "^2.2.5",
-        "@playpass/replicant-lite": "^1.4.0",
+        "@playpass/replicant-lite": "1.4.1",
         "archiver": "^5.3.0",
         "axios": "^0.26.1",
         "bytes": "^3.1.2",
@@ -1441,9 +1441,9 @@
       "license": "UNLICENSED"
     },
     "node_modules/@playpass/replicant-lite": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@playpass/replicant-lite/-/replicant-lite-1.4.0.tgz",
-      "integrity": "sha512-uD8Vzl6U/LeyBsya7/adRzoMspqalqRVWQ9+TEAvC5kWGiqHh42P+sohYMYLaxG40cW2fgF5Djofll59rhA5sg=="
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@playpass/replicant-lite/-/replicant-lite-1.4.1.tgz",
+      "integrity": "sha512-5KCnzUCs7dSUEyMdoSyobzvbwAF/0yWEmYbf6lI6DsV+906g4fYhjWKryjX2CA5i3gOGUHOS5yVkq6p2ALI6pg=="
     },
     "node_modules/@samverschueren/stream-to-observable": {
       "version": "0.3.1",
@@ -15328,9 +15328,9 @@
       "dev": true
     },
     "@playpass/replicant-lite": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@playpass/replicant-lite/-/replicant-lite-1.4.0.tgz",
-      "integrity": "sha512-uD8Vzl6U/LeyBsya7/adRzoMspqalqRVWQ9+TEAvC5kWGiqHh42P+sohYMYLaxG40cW2fgF5Djofll59rhA5sg=="
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@playpass/replicant-lite/-/replicant-lite-1.4.1.tgz",
+      "integrity": "sha512-5KCnzUCs7dSUEyMdoSyobzvbwAF/0yWEmYbf6lI6DsV+906g4fYhjWKryjX2CA5i3gOGUHOS5yVkq6p2ALI6pg=="
     },
     "@samverschueren/stream-to-observable": {
       "version": "0.3.1",
@@ -15915,7 +15915,8 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "acorn-walk": {
       "version": "7.2.0",
@@ -17751,7 +17752,8 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-header/-/eslint-plugin-header-3.1.1.tgz",
       "integrity": "sha512-9vlKxuJ4qf793CmeeSrZUvVClw6amtpghq3CuWcB5cUNnWHQhgcqy5eF8oVKFk1G3Y/CbchGfEaw3wiIJaNmVg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-plugin-react": {
       "version": "7.29.4",
@@ -20068,7 +20070,8 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
       "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "jest-regex-util": {
       "version": "26.0.0",
@@ -24981,7 +24984,8 @@
       "version": "7.5.7",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.7.tgz",
       "integrity": "sha512-KMvVuFzpKBuiIXW3E4u3mySRO2/mCHSyZDJQM5NQ9Q9KHWHWh0NHgfbRMLLrceUK5qAL4ytALJbpRMjixFZh8A==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "xdg-basedir": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "homepage": "https://playpass.games",
   "dependencies": {
     "@iarna/toml": "^2.2.5",
-    "@playpass/replicant-lite": "^1.4.0",
+    "@playpass/replicant-lite": "1.4.1",
     "archiver": "^5.3.0",
     "axios": "^0.26.1",
     "bytes": "^3.1.2",


### PR DESCRIPTION
Bumps replicant-lite to 1.4.1. Includes a fix for leaderboard sort order. 