### PR TITLE
fix docs typo, fix cli help typo

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -35,10 +35,10 @@ Use the `playpass custom-domain create` command first:
 playpass custom-domain create <domain> --certificate <certificatePath> --privateKey <privateKeyPath> [--certificateChain <certificateChainPath>]
 ```
 
-You can also create it outside of your game's directory with the `gameId` flag:
+You can also create it outside of your game's directory with the `game` flag:
 
 ```shell
-playpass custom-domain create <domain> --certificate <certificatePath> --privateKey <privateKeyPath> [--certificateChain <certificateChainPath> --gameId <gameId>]
+playpass custom-domain create <domain> --certificate <certificatePath> --privateKey <privateKeyPath> [--certificateChain <certificateChainPath> --game <gameId>]
 ```
 
 To set up a custom domain with the CLI you need to provide the domain (e.g. `foo.example.com`) and its respective PEM encoded SSL certificate and private key.

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -74,7 +74,7 @@ customDomain
 
 customDomain
     .command("create")
-    .argument("<domain", "Custom domain")
+    .argument("<domain>", "Custom domain")
     .requiredOption("--certificate <certificatePath>", "Path to the PEM-encoded certificate")
     .requiredOption("--privateKey <privateKeyPath>", "Path to the PEM-encoded certificate private key")
     .option("--certificateChain <certificateChainPath>", "Path to the PEM-encoded full certificate chain")


### PR DESCRIPTION
Fixes a typo in the CLI as well as a tweak to the docs now that the argument is game instead of gameId