### PR TITLE
[PGP-302] fix handling of feature flags when no flag is present in gcinstant module

### DIFF
--- a/src/gcinstant.ts
+++ b/src/gcinstant.ts
@@ -81,7 +81,7 @@ class PlatformImpl extends PlatformWeb {
 }
 
 
-class AmplitudeAnalytics implements Analytics {
+export class AmplitudeAnalytics implements Analytics {
     track (name: string, props?: Record<string,unknown>) {
         gcAnalytics.pushEvent(name, props);
     }

--- a/src/gcinstant.ts
+++ b/src/gcinstant.ts
@@ -87,18 +87,20 @@ class AmplitudeAnalytics implements Analytics {
     }
 
     setUserProperties (props: Record<string,unknown>) {
-        // amplitude doesn't support featureFlags in a {key: value} format, so we flatten it into an array.
-        const flattenedFeatureFlags = Object.entries(props.featureFlags as Record<string, unknown>).reduce((acc, [key, val]) => {
-            if(val) {
-                acc.push(key);
-            }
-            return acc;
-        }, [] as string[]);
+        const amplitudeUserProps = {...props};
 
-        gcAnalytics.setUserProperties({
-            ...props,
-            featureFlags: flattenedFeatureFlags,
-        } as Record<string, unknown>);
+        if (amplitudeUserProps.featureFlags) {
+            // amplitude doesn't support featureFlags in a {key: value} format, so we flatten it into an array.
+            const flattenedFeatureFlags = Object.entries(props.featureFlags as Record<string, unknown>).reduce((acc, [key, val]) => {
+                if(val) {
+                    acc.push(key);
+                }
+                return acc;
+            }, [] as string[]);
+            amplitudeUserProps.featureFlags  = flattenedFeatureFlags;
+        }
+
+        gcAnalytics.setUserProperties(amplitudeUserProps);
     }
 }
 

--- a/test/analytics/gcinstant.test.ts
+++ b/test/analytics/gcinstant.test.ts
@@ -1,0 +1,57 @@
+//
+// Playpass (c) Playco
+// https://github.com/playpassgames/playpass/blob/main/LICENSE.txt
+
+import { AmplitudeAnalytics } from "../../src/gcinstant";
+import * as gcinstant from "@play-co/gcinstant";
+
+jest.mock("@play-co/gcinstant", () => {
+    const old = jest.requireActual("@play-co/gcinstant");
+    return {
+        ...old,
+        analytics: {
+            setUserProperties: jest.fn(),
+        },
+    };
+});
+
+jest.mock("../../src/storage/idb-storage", () => {
+    return {
+        IDBStorage: class {
+            get = jest.fn();
+            set = jest.fn();
+        }
+    };
+});
+
+
+describe("GCinstant analytics", () => {
+    it("Should flatten the feature flags when they are set", async () => {
+        const analytics = new AmplitudeAnalytics();
+
+        analytics.setUserProperties({
+            userId: "123",
+            featureFlags: {
+                "feature-1": true,
+                "feature-2": false,
+            }
+        });
+
+        expect(gcinstant.analytics.setUserProperties).toHaveBeenCalledWith({
+            userId: "123",
+            featureFlags: ["feature-1"]
+        });
+    });
+
+    it("Should set user properties when no feature flags are set", async () => {
+        const analytics = new AmplitudeAnalytics();
+
+        analytics.setUserProperties({
+            userId: "123",
+        });
+
+        expect(gcinstant.analytics.setUserProperties).toHaveBeenCalledWith({
+            userId: "123",
+        });
+    });
+});


### PR DESCRIPTION
`props.featureFlags` is not always defined so this could fail when setting user props without any feature flags.