### PR TITLE
Use fetch with `keepalive` for more reliable POST requests.

### DIFF
--- a/src/analytics/playpass-analytics.ts
+++ b/src/analytics/playpass-analytics.ts
@@ -3,7 +3,7 @@
 // https://github.com/playpassgames/playpass/blob/main/LICENSE.txt
 
 import { Analytics } from "./analytics";
-import { randomId } from "../utils";
+import { randomId, sendBackground } from "../utils";
 import { getPlayerId } from "../init";
 
 // Milliseconds to wait before flushing a batch of events
@@ -27,25 +27,8 @@ type EventData = {
 };
 
 // Sends a request to the backend API
-function send(body: RequestData) {
-    const url = "https://t.playpass.games/record";
-    const json = JSON.stringify(body);
-
-    // Use the beacon API if available, otherwise fallback to fetch
-    if (navigator.sendBeacon) {
-        navigator.sendBeacon(
-            url,
-            new Blob([json], { type: "application/json" })
-        );
-    } else {
-        void fetch(url, {
-            method: "POST",
-            headers: {
-                "Content-Type": "application/json",
-            },
-            body: json,
-        });
-    }
+function record(body: RequestData) {
+    sendBackground("https://t.playpass.games/record", body);
 }
 
 export class PlaypassAnalytics implements Analytics {
@@ -112,7 +95,7 @@ export class PlaypassAnalytics implements Analytics {
         if (this.eventQueue.length) {
             // console.log("Will send events", this.eventQueue.slice());
             if (this.gameId) {
-                send({
+                record({
                     project_id: this.gameId,
                     events: this.eventQueue,
                 });

--- a/src/share/index.ts
+++ b/src/share/index.ts
@@ -5,7 +5,7 @@
 import { analytics } from "../analytics";
 import { encode } from "../links";
 import { getPlayerId } from "../init";
-import { shortHash } from "../utils";
+import { shortHash, sendBackground } from "../utils";
 
 import { ShareType } from "./share-type";
 
@@ -229,25 +229,10 @@ export function createLink(opts?: CreateLinkOptions) {
     }, meta);
 
     // Perform a background API request to actually create the shortlink
-    void callShortener(longUrl);
+    sendBackground("https://api.playpass.link", { url: longUrl });
 
     // We locally compute what the shortlink will be to avoid waiting
     return `https://${shortDomain}/${shortHash(longUrl)}`;
-}
-
-async function callShortener (longUrl: string): Promise<void> {
-    const response = await fetch("https://api.playpass.link", {
-        method: "POST",
-        headers: {
-            "Content-Type": "application/json",
-            "Authorization": "Basic d29yZHMuZ2c6RHV4ZXRTMVhPTXBEd3JjZA==",
-        },
-        body: JSON.stringify({
-            url: longUrl,
-        }),
-    });
-
-    await response.json();
 }
 
 /** @hidden */

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -41,3 +41,16 @@ export function shortHash (input: string) {
     }
     return output;
 }
+
+/** Post a JSON object to a URL. */
+export function sendBackground (url: string, body: unknown): void {
+    void fetch(url, {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json",
+        },
+        body: JSON.stringify(body),
+        keepalive: true,
+    });
+}
+


### PR DESCRIPTION
`navigator.sendBeacon` seems to be blocked by some plugins.
