### PR TITLE
Add `trackProps` option to `CreateLinkOptions`.

### DIFF
--- a/src/gcinstant.ts
+++ b/src/gcinstant.ts
@@ -178,7 +178,14 @@ function sendEntryFinalAnalytics (
     }
 
     const standardEntryFinalEventProperties = {
-        // Nothing yet
+        entryHref: document.location.href,
+        entryPath: document.location.pathname.toLowerCase(),
+        entryIsWebview: webview,
+        entryDetectedSocialApp: app,
+        entryUserAgent: navigator.userAgent,
+        entryReferrerHost: referrer?.hostname,
+        entryReferrerToplevelHost: toplevelHost,
+        entryReferrerHref: referrer?.href,
     };
 
     const standardFirstEntryUserProperties = {

--- a/src/gcinstant.ts
+++ b/src/gcinstant.ts
@@ -16,7 +16,7 @@ import { getPWADisplayMode } from "./pwa";
 import { getPlayerId } from "./init";
 import { setGCSharePayload } from "./share";
 import { internalStorage } from "./storage";
-import getQueryParameters from "./utils";
+import { getQueryParameters, camelCasePrefix } from "./utils";
 import { getBestShareType, isWebview } from "./device";
 
 let gcPlatform: PlatformImpl;
@@ -177,38 +177,31 @@ function sendEntryFinalAnalytics (
         toplevelHost = referrer.hostname.split(".").slice(-2).join(".");
     }
 
-    const standardEntryFinalEventProperties = {
-        entryHref: document.location.href,
-        entryPath: document.location.pathname.toLowerCase(),
-        entryIsWebview: webview,
-        entryDetectedSocialApp: app,
-        entryUserAgent: navigator.userAgent,
-        entryReferrerHost: referrer?.hostname,
-        entryReferrerToplevelHost: toplevelHost,
-        entryReferrerHref: referrer?.href,
+    const trackProps = decode().trackProps;
+
+    const standardEntryFinalEventProperties: Record<string,unknown> = {
+        href: document.location.href,
+        path: document.location.pathname.toLowerCase(),
+        isWebview: webview,
+        detectedSocialApp: app,
+        userAgent: navigator.userAgent,
+        referrerHost: referrer?.hostname,
+        referrerToplevelHost: toplevelHost,
+        referrerHref: referrer?.href,
+
+        // ... shareOriginApp, feature, subFeature
+        ...trackProps,
     };
 
-    const standardFirstEntryUserProperties = {
-        firstEntryHref: document.location.href,
-        firstEntryPath: document.location.pathname.toLowerCase(),
-        firstEntryIsWebview: webview,
-        firstEntryDetectedSocialApp: app,
-        firstEntryUserAgent: navigator.userAgent,
-        firstEntryReferrerHost: referrer?.hostname,
-        firstEntryReferrerToplevelHost: toplevelHost,
-        firstEntryReferrerHref: referrer?.href,
-    };
+    const standardFirstEntryUserProperties: Record<string,unknown> = {};
+    const standardLastEntryUserProperties: Record<string,unknown> = {};
 
-    const standardLastEntryUserProperties = {
-        lastEntryHref: document.location.href,
-        lastEntryPath: document.location.pathname.toLowerCase(),
-        lastEntryIsWebview: webview,
-        lastEntryDetectedSocialApp: app,
-        lastEntryUserAgent: navigator.userAgent,
-        lastEntryReferrerHost: referrer?.hostname,
-        lastEntryReferrerToplevelHost: toplevelHost,
-        lastEntryReferrerHref: referrer?.href,
-    };
+    // Generate firstEntry* and lastEntry* user properties based on the EntryFinal event props
+    for (const key in standardEntryFinalEventProperties) {
+        const value = standardEntryFinalEventProperties[key];
+        standardFirstEntryUserProperties[camelCasePrefix("firstEntry", key)] = value;
+        standardLastEntryUserProperties[camelCasePrefix("lastEntry", key)] = value;
+    }
 
     return gcPlatform.sendEntryFinalAnalytics(
         { ...standardEntryFinalEventProperties, ...entryFinalEventProperties },

--- a/src/links.ts
+++ b/src/links.ts
@@ -20,6 +20,9 @@ type Payload = {
     /** Tracking parameters to send along with the entry event. */
     // TODO(2022-03-18): Rename to "entry" when we remove gcinstant
     gcinstant?: Record<string,unknown>,
+
+    /** See CreateLinkOptions.trackProps. */
+    trackProps?: Record<string,unknown>,
 };
 
 let cachedPayload: Payload;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -12,7 +12,7 @@ export function randomId (prefix: string) {
     return str;
 }
 
-export default function getQueryParameters(url?: string): {
+export function getQueryParameters(url?: string): {
   [key: string]: string;
 } {
     const search = url ? new URL(url).search : window.location.search;
@@ -42,6 +42,10 @@ export function shortHash (input: string) {
     return output;
 }
 
+export function camelCasePrefix (prefix: string, str: string): string {
+    return prefix + str.charAt(0).toUpperCase() + str.substring(1);
+}
+
 /** Post a JSON object to a URL. */
 export function sendBackground (url: string, body: unknown): void {
     void fetch(url, {
@@ -53,4 +57,3 @@ export function sendBackground (url: string, body: unknown): void {
         keepalive: true,
     });
 }
-


### PR DESCRIPTION
This allows Playpass to automatically pass through custom
EntryFinal/EntryConversion event properties and lastEntry/firstEntry
user properties through to GCInstant.

Also added shareOriginApp (and
firstEntryShareOriginApp/lastEntryOriginApp) to make it easier to
analyze the social app that the share was sent from.